### PR TITLE
Location property not allowed at resource group scope

### DIFF
--- a/examples/DEPLOYMENT.md
+++ b/examples/DEPLOYMENT.md
@@ -72,7 +72,6 @@ jobs:
           type: deployment
           operation: create
           name: Development
-          location: westus2
           scope: resourceGroup
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: example


### PR DESCRIPTION
Error when using the create example. 
Deployment on resource group scope uses the location from the resource group, no need to define in workflow.  Work ok when removing.

{
  "code": "InvalidDeployment",
  "message": "The 'location' property is not allowed for 'Development' at resource group scope. Please see https://aka.ms/arm-deployment-subscription for usage details."
}